### PR TITLE
typo fix - close parens without open parens, also felt like it needed an 

### DIFF
--- a/ENDER.md
+++ b/ENDER.md
@@ -1,4 +1,3 @@
-
 <div id="intro"></div>
 
 ## INTRODUCTION
@@ -228,7 +227,7 @@ Provides the current status of your built Ender library. This information includ
 
 ### SEARCH
 
-Looks up keywords against NPM's registry and surfaces the most relevant packages. It promotes results for known ender compatible packages and also generic npm matches).
+Looks up keywords against NPM's registry and surfaces the most relevant packages. It promotes results for known ender compatible packages (and lists generic npm matches below).
 
     $ ender search underscore
 


### PR DESCRIPTION
typo fix - close parens without open parens, also felt like it needed an extra word in contrast to 'promotes'
