### PR TITLE
remove twitter @anywhere cause it's deprecated

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -202,7 +202,7 @@ ul li: nth-child(odd) {
 =============*/
 
 header .left {
-  background: url('/img/battle.jpg') no-repeat 30px 90px;
+  background: url('/img/battle.jpg') no-repeat 30px 75px;
   height: 470px;
   width: 470px;
   float: left;

--- a/views/layout.html
+++ b/views/layout.html
@@ -40,11 +40,6 @@
     {% block content %}{% endblock %}
 
     <script src="/js/ender.min.js"></script>
-    <script src="//platform.twitter.com/anywhere.js?id=frmB6pZo25QLmwMoV4z5Cw&v=1"></script>
-    <script type="text/javascript">
-      var _gaq = [ [ '_setAccount', 'UA-22894426-1'], ['_trackPageview']]
-      twttr.anywhere(function (T) { T.hovercards() })
-    </script>
     <script src='//www.google-analytics.com/ga.js'></script>
   </body>
 </html>


### PR DESCRIPTION
Reduces some of the client-side errors in chrome. Still a bunch because of vimeo's bug until they fix it.
